### PR TITLE
SubString() replaced with String.Contains

### DIFF
--- a/resources/skins/Default/720p/screensaver-video-main.xml
+++ b/resources/skins/Default/720p/screensaver-video-main.xml
@@ -54,7 +54,7 @@
 					<height>135</height>
 					<aspectratio>keep</aspectratio>
 					<texture>$INFO[ListItem.ActualIcon]</texture>
-	  				<visible>SubString(ListItem.ActualIcon, resource.images.weathericons.default)</visible>
+	  				<visible>String.Contains(ListItem.ActualIcon, resource.images.weathericons.default)</visible>
 				</control>
 				<control type="image">
 					<left>0</left>
@@ -63,7 +63,7 @@
 					<height>135</height>
 					<aspectratio>keep</aspectratio>
 					<texture>resource://resource.images.weathericons.default/$INFO[ListItem.ActualIcon]</texture>
-	  				<visible>!SubString(ListItem.ActualIcon, resource.images.weathericons.default)</visible>
+	  				<visible>!String.Contains(ListItem.ActualIcon, resource.images.weathericons.default)</visible>
 				</control>
 				<control type="label">
 					<left>150</left>
@@ -106,7 +106,7 @@
 					<height>135</height>
 					<aspectratio>keep</aspectratio>
 					<texture>$INFO[ListItem.ActualIcon]</texture>
-	  				<visible>SubString(ListItem.ActualIcon, resource.images.weathericons.default)</visible>
+	  				<visible>String.Contains(ListItem.ActualIcon, resource.images.weathericons.default)</visible>
 				</control>
 				<control type="image">
 					<left>0</left>
@@ -115,7 +115,7 @@
 					<height>135</height>
 					<aspectratio>keep</aspectratio>
 					<texture>resource://resource.images.weathericons.default/$INFO[ListItem.ActualIcon]</texture>
-	  				<visible>!SubString(ListItem.ActualIcon, resource.images.weathericons.default)</visible>
+	  				<visible>!String.Contains(ListItem.ActualIcon, resource.images.weathericons.default)</visible>
 				</control>
 				<control type="label">
 					<left>150</left>


### PR DESCRIPTION
2016-12-12 removed infobools

these old deprecated infobools have now been removed:

-     StringCompare() (use String.IsEqual instead)
-     SubString() (use String.Contains instead)
-     IntegerGreaterThan() (use Integer.IsGreater instead)
-     IsEmpty() (use String.IsEmpty instead)

[https://github.com/xbmc/xbmc/pull/11058](https://github.com/xbmc/xbmc/pull/11058)
[https://github.com/xbmc/xbmc/commit/541576b03ea7a695b68cde557662991ace7f3f42](https://github.com/xbmc/xbmc/commit/541576b03ea7a695b68cde557662991ace7f3f42)