### PR TITLE
IsEmpty() replaced with String.IsEmpty

### DIFF
--- a/resources/skins/Default/720p/screensaver-video-main.xml
+++ b/resources/skins/Default/720p/screensaver-video-main.xml
@@ -84,7 +84,7 @@
 					<textcolor>FFF1F1F1</textcolor>
 					<shadowcolor>FF000000</shadowcolor>
 					<label>[COLOR=FF999999]$LOCALIZE[419] : [/COLOR]$INFO[ListItem.Property(HighTemp)]$INFO[ListItem.Property(TempUnits)]     [COLOR=FF999999]$LOCALIZE[418] : [/COLOR]$INFO[ListItem.Property(LowTemp)]$INFO[ListItem.Property(TempUnits)]</label>
-	  				<visible>!IsEmpty(ListItem.Property(HighTemp))</visible>
+	  				<visible>!String.IsEmpty(ListItem.Property(HighTemp))</visible>
 				</control>
 				<control type="textbox">
 					<left>150</left>
@@ -136,7 +136,7 @@
 					<textcolor>FFF1F1F1</textcolor>
 					<shadowcolor>FF000000</shadowcolor>
 					<label>[COLOR=FF999999]$LOCALIZE[419] : [/COLOR]$INFO[ListItem.Property(HighTemp)]$INFO[ListItem.Property(TempUnits)]     [COLOR=FF999999]$LOCALIZE[418] : [/COLOR]$INFO[ListItem.Property(LowTemp)]$INFO[ListItem.Property(TempUnits)]</label>
-	  				<visible>!IsEmpty(ListItem.Property(HighTemp))</visible>
+	  				<visible>!String.IsEmpty(ListItem.Property(HighTemp))</visible>
 				</control>
 				<control type="textbox">
 					<left>150</left>
@@ -159,7 +159,7 @@
 					<property name="Outlook">$INFO[Window(12600).Property(Day0.Outlook)]</property>
 					<property name="TempUnits">$INFO[System.TemperatureUnits]</property>
 					<onclick>noop</onclick>
-					<visible>Weather.IsFetched + !IsEmpty(Window(12600).Property(Day0.Outlook))</visible>
+					<visible>Weather.IsFetched + !String.IsEmpty(Window(12600).Property(Day0.Outlook))</visible>
 				</item>
 				<item>
 					<label>$INFO[Window(12600).Property(Day1.Title)]</label>
@@ -169,7 +169,7 @@
 					<property name="Outlook">$INFO[Window(12600).Property(Day1.Outlook)]</property>
 					<property name="TempUnits">$INFO[System.TemperatureUnits]</property>
 					<onclick>noop</onclick>
-					<visible>Weather.IsFetched + !IsEmpty(Window(12600).Property(Day1.Outlook))</visible>
+					<visible>Weather.IsFetched + !String.IsEmpty(Window(12600).Property(Day1.Outlook))</visible>
 				</item>
 				<item>
 					<label>$INFO[Window(12600).Property(Day2.Title)]</label>
@@ -179,7 +179,7 @@
 					<property name="Outlook">$INFO[Window(12600).Property(Day2.Outlook)]</property>
 					<property name="TempUnits">$INFO[System.TemperatureUnits]</property>
 					<onclick>noop</onclick>
-					<visible>Weather.IsFetched + !IsEmpty(Window(12600).Property(Day2.Outlook))</visible>
+					<visible>Weather.IsFetched + !String.IsEmpty(Window(12600).Property(Day2.Outlook))</visible>
 				</item>
 				<item>
 					<label>$INFO[Window(12600).Property(Day3.Title)]</label>
@@ -189,7 +189,7 @@
 					<property name="Outlook">$INFO[Window(12600).Property(Day3.Outlook)]</property>
 					<property name="TempUnits">$INFO[System.TemperatureUnits]</property>
 					<onclick>noop</onclick>
-					<visible>Weather.IsFetched + !IsEmpty(Window(12600).Property(Day3.Outlook))</visible>
+					<visible>Weather.IsFetched + !String.IsEmpty(Window(12600).Property(Day3.Outlook))</visible>
 				</item>
 				<item>
 					<label>$INFO[Window(12600).Property(Day4.Title)]</label>
@@ -199,7 +199,7 @@
 					<property name="Outlook">$INFO[Window(12600).Property(Day4.Outlook)]</property>
 					<property name="TempUnits">$INFO[System.TemperatureUnits]</property>
 					<onclick>noop</onclick>
-					<visible>Weather.IsFetched + !IsEmpty(Window(12600).Property(Day4.Outlook))</visible>
+					<visible>Weather.IsFetched + !String.IsEmpty(Window(12600).Property(Day4.Outlook))</visible>
 				</item>
 				<item>
 					<label>$INFO[Window(12600).Property(Day5.Title)]</label>
@@ -209,7 +209,7 @@
 					<property name="Outlook">$INFO[Window(12600).Property(Day5.Outlook)]</property>
 					<property name="TempUnits">$INFO[System.TemperatureUnits]</property>
 					<onclick>noop</onclick>
-					<visible>Weather.IsFetched + !IsEmpty(Window(12600).Property(Day5.Outlook))</visible>
+					<visible>Weather.IsFetched + !String.IsEmpty(Window(12600).Property(Day5.Outlook))</visible>
 				</item>
 				<item>
 					<label>$INFO[Window(12600).Property(Day6.Title)]</label>
@@ -219,7 +219,7 @@
 					<property name="Outlook">$INFO[Window(12600).Property(Day6.Outlook)]</property>
 					<property name="TempUnits">$INFO[System.TemperatureUnits]</property>
 					<onclick>noop</onclick>
-					<visible>Weather.IsFetched + !IsEmpty(Window(12600).Property(Day6.Outlook))</visible>
+					<visible>Weather.IsFetched + !String.IsEmpty(Window(12600).Property(Day6.Outlook))</visible>
 				</item>
 			</content>
 		</control>


### PR DESCRIPTION
2016-12-12 removed infobools

these old deprecated infobools have now been removed:

-     StringCompare() (use String.IsEqual instead)
-     SubString() (use String.Contains instead)
-     IntegerGreaterThan() (use Integer.IsGreater instead)
-     IsEmpty() (use String.IsEmpty instead)

[https://github.com/xbmc/xbmc/pull/11058](https://github.com/xbmc/xbmc/pull/11058)
[https://github.com/xbmc/xbmc/commit/541576b03ea7a695b68cde557662991ace7f3f42](https://github.com/xbmc/xbmc/commit/541576b03ea7a695b68cde557662991ace7f3f42)